### PR TITLE
Fix usage of deprecated code in tests

### DIFF
--- a/test/flutter_pax_printer_utility_test.dart
+++ b/test/flutter_pax_printer_utility_test.dart
@@ -8,13 +8,15 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
       return '42';
     });
   });
 
   tearDown(() {
-    channel.setMockMethodCallHandler(null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
   });
 
   test('getPlatformVersion', () async {


### PR DESCRIPTION
See deprecation notice: [https://api.flutter.dev/flutter/flutter_test/TestMethodChannelExtension/setMockMethodCallHandler.html](https://api.flutter.dev/flutter/flutter_test/TestMethodChannelExtension/setMockMethodCallHandler.html)